### PR TITLE
match correct current gtid

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SnapshotReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SnapshotReader.java
@@ -675,6 +675,53 @@ public class SnapshotReader extends AbstractReader {
         }
     }
 
+    protected String getMasterServerUUID(JdbcConnection mysql) throws SQLException {
+        String showSlaveStmt = "SHOW SLAVE STATUS";
+        Statement stmt = mysql.connection().createStatement();
+        ResultSet rs = stmt.executeQuery(showSlaveStmt);
+        String masterUUID = rs.getString("Master_UUID");
+        return masterUUID;
+    }
+
+    protected String extractCurrentGtid(String masterSeverUUID, String executedGtidSet) {
+        // gtid_set:
+        //    uuid_set [, uuid_set] ...
+        //    | ''
+        //
+        //uuid_set:
+        //    uuid:interval[:interval]...
+        //
+        //uuid:
+        //    hhhhhhhh-hhhh-hhhh-hhhh-hhhhhhhhhhhh
+        //
+        //h:
+        //    [0-9|A-F]
+        //
+        //interval:
+        //    n[-n]
+        //
+        //    (n >= 1)
+        String[] splitedGtidSet = executedGtidSet.trim().split(",");
+        for (String executedGtid: splitedGtidSet) {
+            String trimedExecutedGtid = executedGtid.trim();
+            if (trimedExecutedGtid.isEmpty()) {
+                continue;
+            }
+            String[] seq = trimedExecutedGtid.split(":");
+            if (!seq[0].equals(masterSeverUUID)) {
+                continue;
+            }
+            String interval = seq[seq.length - 1];
+            if (!interval.contains("-")) {
+                return masterSeverUUID + ":" + interval;
+            } else {
+                String currentTransactionId = interval.split("-")[1];
+                return masterSeverUUID + ":" + currentTransactionId;
+            }
+        }
+        return null;
+    }
+
     protected void readBinlogPosition(int step, SourceInfo source, JdbcConnection mysql, AtomicReference<String> sql) throws SQLException {
         if (context.isSchemaOnlyRecoverySnapshot()) {
             // We are in schema only recovery mode, use the existing binlog position
@@ -685,10 +732,12 @@ public class SnapshotReader extends AbstractReader {
             source.startSnapshot();
         } else {
             logger.info("Step {}: read binlog position of MySQL master", step);
+
             String showMasterStmt = "SHOW MASTER STATUS";
             sql.set(showMasterStmt);
             mysql.query(sql.get(), rs -> {
                 if (rs.next()) {
+                    String masterServerUUID = getMasterServerUUID(mysql);
                     String binlogFilename = rs.getString(1);
                     long binlogPosition = rs.getLong(2);
                     source.setBinlogStartPoint(binlogFilename, binlogPosition);
@@ -698,12 +747,16 @@ public class SnapshotReader extends AbstractReader {
                         source.setCompletedGtidSet(gtidSet);
 
                         if (gtidSet != null && !gtidSet.trim().isEmpty()) {
-                            String[] splitedGtidSet = gtidSet.trim().split(",");
-                            String currentExecutedGtid = splitedGtidSet[splitedGtidSet.length - 1].trim();
-                            // Just set current gtid
-                            String serverUUID = currentExecutedGtid.split(":")[0];
-                            String currentTransactionId = currentExecutedGtid.split(":")[1].split("-")[1];
-                            String currentGtid = serverUUID + ":" + currentTransactionId;
+
+                            String currentGtid = extractCurrentGtid(masterServerUUID, gtidSet);
+                            if (currentGtid == null) {
+                                String errorMsg = "can not find current gtid. masterServerUUID: "
+                                        + masterServerUUID + " "
+                                        + "executedGtidSet: " + gtidSet;
+                                logger.error(errorMsg);
+                                throw new RuntimeException(errorMsg);
+                            }
+                            logger.info("current gtid " + currentGtid);
                             source.startGtid(currentGtid, null);
                         }
                         logger.info("\t using binlog '{}' at position '{}' and gtid '{}'", binlogFilename, binlogPosition,


### PR DESCRIPTION
executed_gtid_set 可能包括多个 server_uuid

通过 `show slave status`(mysql 为 slave 时) 或 `select @@server_uuid`(mysql 为 master 时) 返回的 `Master_UUID`，从 executed_gtid_set 中找出当前的 gtid